### PR TITLE
Copied comment about NIST is invalid for SI

### DIFF
--- a/bitmath/__init__.py
+++ b/bitmath/__init__.py
@@ -108,7 +108,7 @@ _FORMAT_REPR = '{unit_singular}({value})'
 #: Constants for referring to NIST prefix system
 NIST = int(2)
 
-#: Constants for referring to NIST prefix system
+#: Constants for referring to SI prefix system
 SI = int(10)
 
 # ##################################


### PR DESCRIPTION
Just small typo, perhaps because of copied comment.