### PR TITLE
Added __format__ method

### DIFF
--- a/bitmath/__init__.py
+++ b/bitmath/__init__.py
@@ -413,6 +413,19 @@ interpreter"""
         global format_string
         return self.format(format_string)
 
+    def __format__(self, format_spec):
+        """String representation of this object with custom formatting, such as specified number of digits."""
+        global format_string
+        try:
+            # replace any format spec added into global format_string with the format_spec used in this invocation
+            value_end = format_string.index('{value') + 6
+            brace_index = format_string.index('}', value_end)
+            format_string_custom = format_string[:value_end] + ':' + format_spec + format_string[brace_index:]
+        except ValueError:
+            # no {value} found in format_string, so cannot customize; fall back to global format_string
+            format_string_custom = format_string
+        return self.format(format_string_custom)
+
     def format(self, fmt):
         """Return a representation of this instance formatted with user
 supplied syntax"""

--- a/tests/test_representation.py
+++ b/tests/test_representation.py
@@ -146,3 +146,39 @@ manager. There is a separate test suite for that: test_context_manager"""
         one_Byte = bitmath.Byte(1.0)
         actual_result = one_Byte.format(fmt_str)
         self.assertEqual(expected_result, actual_result)
+
+    def test_inline_format(self):
+        """Inline string formatting interpolates default format_string values"""
+        expected_result = 'size: 3.1215 MiB'
+        size = bitmath.MiB(3.1215)
+        actual_result = 'size: {size}'.format(size=size)
+        self.assertEqual(expected_result, actual_result) 
+
+    def test_inline_format_customized(self):
+        """Inline formats obey inline format specifications"""
+        expected_result = 'size: 3.1 MiB'
+        size = bitmath.MiB(3.1215)
+        actual_result = 'size: {size:.1f}'.format(size=size)
+        self.assertEqual(expected_result, actual_result) 
+
+    def test_inline_format_override(self):
+        """Inline formats use module defaults, overriding only format spec"""
+        orig_fmt_str = bitmath.format_string
+        bitmath.format_string = "{unit} {value:.3f}"
+        expected_result = 'size: MiB 3.1'
+        size = bitmath.MiB(3.1215)
+        actual_result = 'size: {size:.1f}'.format(size=size)
+        self.assertEqual(expected_result, actual_result) 
+        bitmath.format_string = orig_fmt_str
+
+    def test_inline_format_cant_override(self):
+        """Inline formats use module defaults, changing nothing if no {value} component"""
+        orig_fmt_str = bitmath.format_string
+        bitmath.format_string = "{power} {binary}"
+        expected_result = 'size: 20 0b1100011111000110101001111'
+        size = bitmath.MiB(3.1215)
+        # will not obey instant formatting, because global format_string doesn't allow that;
+        # obeys the global format_string instead
+        actual_result = 'size: {size:.1f}'.format(size=size)
+        self.assertEqual(expected_result, actual_result) 
+        bitmath.format_string = orig_fmt_str


### PR DESCRIPTION
- allows specifying precision in inline string formatting
- e.g. 'size: {:0.1f}'.format(s)
- using standard string formatting, not just bitmath.format
- adds corresponding tests

Short description: Adds a __format__ method to enable in-line string interpolation 

If you have a bitmath object (of whatever unit), it's handy to be able to interpolate that value directly in a format string. E.g.:

    size = bitmath.MiB(2.847598437)
    print('size: {:.1f}'.format(size))

A`__format__` method makes this possible. It's even neater in Python 3.6 and following, with its ability to automatically interpolate variables into strings.

    size = bitmath.MiB(2.847598437)
    print(f'size: {size:.1f}')