### PR TITLE
Include 3.7 in travis testing as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,7 @@ matrix:
       env: CI=ci3
     - python: "3.6"
       env: CI=ci3
+    - python: "3.7"
+      env: CI=ci3
 script: make $CI
 install: ""


### PR DESCRIPTION
Short description: Adds Python 3.7 to travis test matrix