### PR TITLE
Only py 3.7 devel version available on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       env: CI=ci3
     - python: "3.6"
       env: CI=ci3
-    - python: "3.7"
+    - python: "3.7-dev"
       env: CI=ci3
 script: make $CI
 install: ""


### PR DESCRIPTION
Short description: Changes the Python 3.7 travis version to "3.7-dev" because 3.7 isn't available yet

https://docs.travis-ci.com/user/languages/python/#specifying-python-versions