### PR TITLE
prefer newer unittest.mock when available

### DIFF
--- a/tests/test_progressbar.py
+++ b/tests/test_progressbar.py
@@ -28,10 +28,14 @@
 Test the progressbar 'FileTransferSpeed' integration
 """
 
+try:
+    import unittest.mock
+except ImportError:
+    import mock
+
 from . import TestCase
 import bitmath
 from bitmath.integrations.bmprogressbar import BitmathFileTransferSpeed
-import mock
 import progressbar
 
 

--- a/tests/test_query_device_capacity.py
+++ b/tests/test_query_device_capacity.py
@@ -30,8 +30,12 @@ Test reading block device capacities
 
 from . import TestCase
 import bitmath
-import mock
 import struct
+
+try:
+    import unittest.mock
+except ImportError:
+    import mock
 
 try:
     # Python 3.3+


### PR DESCRIPTION
Hi, I'm busy removing old Python2-era libraries from Debian.

This one is easy to hybridize.

"mock is now part of the Python standard library, available as [unittest.mock]"

https://github.com/testing-cabal/mock

https://salsa.debian.org/detiste-guest/python3-mock-removal