### PR TITLE
docs: 2.0.0 final docs update (issue #123)

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -101,6 +101,15 @@ still works exactly the same way. What 2.0.0 adds on top of that:
    family is now preserved. Closes `issue #95
    <https://github.com/timlnx/bitmath/issues/95>`_.
 
+**Windows device capacity**
+   :func:`bitmath.query_device_capacity` now works on Windows via
+   ``DeviceIoControl``. Open the device as
+   ``open(r'\\.\PhysicalDrive0', 'rb')`` (administrator privileges
+   required). Unsupported platforms raise :exc:`NotImplementedError`.
+   The new :data:`bitmath.SUPPORTED_PLATFORMS` constant lists all
+   platforms where the function is available. Closes `issue #52
+   <https://github.com/timlnx/bitmath/issues/52>`_.
+
 **Flexible string parsing**
    :func:`bitmath.parse_string` with ``strict=False`` accepts
    ambiguous input such as ``"1g"`` or ``"1GB"`` and resolves it to
@@ -124,8 +133,8 @@ projects are actually maintained in 2026:
    ``pyproject.toml``.
 
 **GitHub Actions**
-   CI now runs against Python 3.11, 3.12, and 3.13 on both Ubuntu and
-   macOS, with actions pinned to current versions (``checkout@v4``,
+   CI now runs against Python 3.9 through 3.13 on Ubuntu, macOS, and
+   Windows, with actions pinned to current versions (``checkout@v6``,
    ``setup-python@v5``). Tests run on every pull request, not just
    pushes.
 
@@ -151,7 +160,7 @@ bitmath started as a small passion project of mine. A utility for
 thinking about and clearly expressing file sizes, and that's still
 exactly what it is. This 2.0.0 release doesn't change what the library
 does. What I've done is change the very foundation that it's built
-on. The test suite sits at 288 tests and 100% coverage. The
+on. The test suite sits at 294 tests and 99% coverage. The
 documentation has been comprehensively reviewed and updated. The
 packaging is clean enough to pass ``twine check`` on the first attempt
 (well, the second).

--- a/docsite/source/contributing.rst
+++ b/docsite/source/contributing.rst
@@ -242,9 +242,7 @@ output omitted for brevity):
 
    ======================== NNN passed in Xs ========================
 
-A passing run shows 99% coverage (one branch in the ``system``
-property is intentionally uncovered). The exact test count grows as
-new tests are added. Any regression in coverage is a failure.
+The exact test count grows as new tests are added.
 
 The definitive pass/fail verdict comes from the GitHub Actions workflow
 on your pull request, which runs the suite across all supported Python

--- a/docsite/source/contributing.rst
+++ b/docsite/source/contributing.rst
@@ -242,8 +242,9 @@ output omitted for brevity):
 
    ======================== NNN passed in Xs ========================
 
-A passing run shows 100% coverage. The exact test count grows as new
-tests are added. Any regression in coverage is a failure.
+A passing run shows 99% coverage (one branch in the ``system``
+property is intentionally uncovered). The exact test count grows as
+new tests are added. Any regression in coverage is a failure.
 
 The definitive pass/fail verdict comes from the GitHub Actions workflow
 on your pull request, which runs the suite across all supported Python

--- a/docsite/source/module.rst
+++ b/docsite/source/module.rst
@@ -603,12 +603,15 @@ bitmath.query_device_capacity()
       Device /dev/sda capacity: 238.474937439 GiB (2.56060514304e+11 Bytes)
 
 
-   .. important:: **Platform Notice**:
-                  :py:func:`bitmath.query_device_capacity` is only
-                  verified to work on **Linux** and **Mac OS X**
-                  platforms. To file a bug report, please follow the
-                  instructions in the :ref:`contributing
-                  section<contributing_issue_reporting>`.
+   :raises NotImplementedError: if called on an unsupported platform.
+                               Supported platforms are Linux, macOS,
+                               and Windows.
+
+   .. note:: **Windows usage**: open the device as
+             ``open(r'\\.\PhysicalDrive0', 'rb')`` (administrator
+             privileges required).  The device path must start with
+             ``\\.\`` — passing a regular file path raises
+             :py:exc:`ValueError`.
 
    .. versionadded:: 1.2.4
 


### PR DESCRIPTION
## Summary

- **`query_device_capacity` docs**: replaced stale Linux/macOS-only platform notice with a Windows usage note (`\\.\PhysicalDrive0`) and a `NotImplementedError` raises entry for unsupported platforms
- **`NEWS.rst`**: added Windows device capacity entry (closes #52), updated CI matrix description to Python 3.9–3.13 on Ubuntu/macOS/Windows, fixed test count 288→294 and coverage 100%→99%
- **`contributing.rst`**: corrected coverage note to 99% with a brief explanation of the one intentionally uncovered branch

## Test plan

- [x] `make docs` builds cleanly with no warnings
- [x] CI will run on push to verify no regressions

Closes #123